### PR TITLE
The toggle between FaTimes and FaBars improved on smaller screens

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -72,7 +72,7 @@ const NavBar = () => {
 
 
         {nav && (
-            <ul className='flex flex-col justify-center items-center absolute top-0 left-0 w-full h-screen bg-gradient-to-b from-black to-blue-900 text-gray-500 z-10'>
+            <ul className='flex flex-col justify-center items-center absolute top-0 left-0 w-full h-screen bg-gradient-to-b from-black to-blue-900 text-gray-500'>
             {links.map(({id, link}) => ( 
                     <li key={id} className='px-4 cursor-pointer capitalize py-6 text-4xl'>
                         <Link onClick={() => setNav(!nav)} 


### PR DESCRIPTION
[FIXED] The icons didn't use to switch between them upon clicking. It has been fixed now.